### PR TITLE
VXC label change to serialize data correctly for Megaport API

### DIFF
--- a/src/Model/Order/Product/AssocVxc.php
+++ b/src/Model/Order/Product/AssocVxc.php
@@ -39,7 +39,7 @@ class AssocVxc
      * @param \Megaport\Model\Order\Product\ConnectableProduct $bEnd
      * @param int $rateLimit
      */
-    public function __construct(string $name, PortVlan $aEnd, CloudVlan $bEnd, $rateLimit = 550)
+    public function __construct(string $name, PortVlan $aEnd, ConnectableProduct $bEnd, $rateLimit = 550)
     {
         $this->name = $name;
         $this->rateLimit = $rateLimit;

--- a/src/Model/Order/Product/AssocVxc.php
+++ b/src/Model/Order/Product/AssocVxc.php
@@ -34,8 +34,8 @@ class AssocVxc
      * AssocVxc constructor.
      *
      * @param string $productName
-     * @param \Megaport\Model\Order\Product\ConnectableProduct $aEnd
-     * @param \Megaport\Model\Order\Product\ConnectableProduct $bEnd
+     * @param \Megaport\Model\Order\Product\PortVlan $aEnd
+     * @param \Megaport\Model\Order\Product\CloudVlan $bEnd
      * @param int $rateLimit
      */
     public function __construct(string $productName, PortVlan $aEnd, CloudVlan $bEnd, $rateLimit = 550)

--- a/src/Model/Order/Product/AssocVxc.php
+++ b/src/Model/Order/Product/AssocVxc.php
@@ -10,7 +10,7 @@ class AssocVxc
      * @var string
      * @SerializerX\Type("string")
      */
-    private $name;
+    private $productName;
 
     /**
      * @var int
@@ -33,14 +33,14 @@ class AssocVxc
     /**
      * AssocVxc constructor.
      *
-     * @param string $name
+     * @param string $productName
      * @param \Megaport\Model\Order\Product\ConnectableProduct $aEnd
      * @param \Megaport\Model\Order\Product\ConnectableProduct $bEnd
      * @param int $rateLimit
      */
-    public function __construct(string $name, ConnectableProduct $aEnd, ConnectableProduct $bEnd, $rateLimit = 550)
+    public function __construct(string $productName, ConnectableProduct $aEnd, ConnectableProduct $bEnd, $rateLimit = 550)
     {
-        $this->name = $name;
+        $this->productName = $productName;
         $this->rateLimit = $rateLimit;
         $this->aEnd = ['vlan' => $aEnd->getVlan()];
         $this->bEnd = $bEnd->getBEndConfig();
@@ -51,7 +51,7 @@ class AssocVxc
      */
     public function getName(): string
     {
-        return $this->name;
+        return $this->productName;
     }
 
     /**

--- a/src/Model/Order/Product/AssocVxc.php
+++ b/src/Model/Order/Product/AssocVxc.php
@@ -38,7 +38,7 @@ class AssocVxc
      * @param \Megaport\Model\Order\Product\ConnectableProduct $bEnd
      * @param int $rateLimit
      */
-    public function __construct(string $productName, ConnectableProduct $aEnd, ConnectableProduct $bEnd, $rateLimit = 550)
+    public function __construct(string $productName, PortVlan $aEnd, CloudVlan $bEnd, $rateLimit = 550)
     {
         $this->productName = $productName;
         $this->rateLimit = $rateLimit;
@@ -49,7 +49,7 @@ class AssocVxc
     /**
      * @return string
      */
-    public function getName(): string
+    public function getProductName(): string
     {
         return $this->productName;
     }

--- a/src/Model/Order/Product/AssocVxc.php
+++ b/src/Model/Order/Product/AssocVxc.php
@@ -36,7 +36,7 @@ class AssocVxc
      *
      * @param string $name
      * @param \Megaport\Model\Order\Product\PortVlan $aEnd
-     * @param \Megaport\Model\Order\Product\CloudVlan $bEnd
+     * @param \Megaport\Model\Order\Product\ConnectableProduct $bEnd
      * @param int $rateLimit
      */
     public function __construct(string $name, PortVlan $aEnd, CloudVlan $bEnd, $rateLimit = 550)

--- a/src/Model/Order/Product/AssocVxc.php
+++ b/src/Model/Order/Product/AssocVxc.php
@@ -9,8 +9,9 @@ class AssocVxc
     /**
      * @var string
      * @SerializerX\Type("string")
+     * @SerializerX\SerializedName("productName")
      */
-    private $productName;
+    private $name;
 
     /**
      * @var int
@@ -29,29 +30,29 @@ class AssocVxc
      * @SerializerX\Type("array")
      */
     private $bEnd;
-
+    
     /**
      * AssocVxc constructor.
      *
-     * @param string $productName
+     * @param string $name
      * @param \Megaport\Model\Order\Product\PortVlan $aEnd
      * @param \Megaport\Model\Order\Product\CloudVlan $bEnd
      * @param int $rateLimit
      */
-    public function __construct(string $productName, PortVlan $aEnd, CloudVlan $bEnd, $rateLimit = 550)
+    public function __construct(string $name, PortVlan $aEnd, CloudVlan $bEnd, $rateLimit = 550)
     {
-        $this->productName = $productName;
+        $this->name = $name;
         $this->rateLimit = $rateLimit;
         $this->aEnd = ['vlan' => $aEnd->getVlan()];
         $this->bEnd = $bEnd->getBEndConfig();
     }
-
+    
     /**
      * @return string
      */
-    public function getProductName(): string
+    public function getName(): string
     {
-        return $this->productName;
+        return $this->name;
     }
 
     /**


### PR DESCRIPTION
Hi, we encountered some bugs at DCspine with the provisioning of VXC products to Megaport, the name field was incorrect in the request, so we made a small change to the SDK to correctly pass the 'productName' field to their API.

Kind regards,
Robbert
Lucas
(DCspine)